### PR TITLE
Add ability to connect Susi Webclient to Susi Hardware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,21 +1,29 @@
 import susi_python as susi
 import speech.TTS as TTS
 import speech_recognition as sr
+import queue as queue
+
+from threading import Thread
+import asyncio
+import websockets
 
 from speech.SphinxRecognizer import SphinxRecognizer
 import pyaudio
 
-r = sr.Recognizer()
-r.dynamic_energy_threshold = False
-r.energy_threshold = 1000
+recognizer = sr.Recognizer()
+recognizer.dynamic_energy_threshold = False
+recognizer.energy_threshold = 1000
+
+# Make a queue for Storing queries by user
+queries_queue = queue.Queue()
 
 # TODO: Set parameters from environment variable.
 # Currently, please set the variables for microphone initialization below manually.
 # Refer following link for more information about parameters
 # https://github.com/Uberi/speech_recognition/blob/master/reference/library-reference.rst#microphonedevice_index--none-sample_rate--16000-chunk_size--1024
 
-#m = sr.Microphone(device_index=2, sample_rate=48000, chunk_size=2048)
-m = sr.Microphone()
+# microphone = sr.Microphone(device_index=2, sample_rate=48000, chunk_size=2048)
+microphone = sr.Microphone()
 
 
 def speak(text):
@@ -44,15 +52,16 @@ def start_speech_recognition():
         #     r.adjust_for_ambient_noise(source)
 
         print("Say something!")
-        print("Energy Threshold " + str(r.energy_threshold))
-        with m as source:
-            audio = r.listen(source, phrase_time_limit=5)
+        print("Energy Threshold " + str(recognizer.energy_threshold))
+        with microphone as source:
+            audio = recognizer.listen(source, phrase_time_limit=5)
         print("Got it! Now to recognize it...")
         try:
             # recognize speech using Google Speech Recognition
-            value = r.recognize_google(audio)
+            value = recognizer.recognize_google(audio)
+            queries_queue.put(value)
             # query susi for the question
-            askSusi(format(value))
+            askSusi(value)
 
         except sr.UnknownValueError:
             print("Oops! Didn't catch that")
@@ -82,9 +91,51 @@ def close_stream():
 
 open_stream()
 
+async def consumer(message):
+    print(message)
+
+
+async def consumer_handler(websocket):
+    while True:
+        message = await websocket.recv()
+        await consumer(message)
+
+
+async def producer():
+    return queries_queue.get()
+
+
+async def producer_handler(websocket):
+    while True:
+        message = await producer()
+        await websocket.send(message)
+
+async def handler(websocket, path):
+    consumer_task = asyncio.ensure_future(consumer_handler(websocket))
+    producer_task = asyncio.ensure_future(producer_handler(websocket))
+    done, pending = await asyncio.wait(
+        [consumer_task, producer_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+
+
+def start_server_thread(handler, loop):
+    start_server = websockets.serve(handler, '127.0.0.1', 5678)
+    asyncio.set_event_loop(loop)
+    asyncio.get_event_loop().run_until_complete(start_server)
+    asyncio.get_event_loop().run_forever()
+
+
 # TODO: Decide threshold by a training based system.
 # adjust threshold manually for now.
 sphinxRecognizer = SphinxRecognizer(threshold=1e-23)
+
+loop = asyncio.get_event_loop()
+thread = Thread(target=start_server_thread, args=(handler, loop,))
+thread.start()
 
 while True:
     buffer = stream.read(30480, exception_on_overflow=False)
@@ -96,3 +147,5 @@ while True:
             open_stream()
     else:
         break
+
+thread.join()

--- a/app/requirements-hw.txt
+++ b/app/requirements-hw.txt
@@ -1,3 +1,4 @@
 speechRecognition==3.6.5
 pocketsphinx==0.1.3
 watson-developer-cloud
+websockets

--- a/app/speech/SphinxRecognizer.py
+++ b/app/speech/SphinxRecognizer.py
@@ -18,6 +18,7 @@ class SphinxRecognizer(object):
         config.set_string('-keyphrase', 'susi')
         config.set_string('-dict', os.path.join(modeldir, dict_name))
         config.set_float('-kws_threshold',self.threshold)
+        config.set_string('-logfn', '/dev/null')
         # TODO: Optimize use of following parameters
         #config.set_float('-samprate', self.sample_rate)
         #config.set_int('-nfft', 2048)

--- a/app/websocket_service.py
+++ b/app/websocket_service.py
@@ -1,0 +1,19 @@
+import threading
+
+from websocket_server import WebsocketServer
+
+
+class WebsocketThread(threading.Thread):
+    def __init__(self, port, fn_new_client, fn_client_left, fn_message_received):
+        threading.Thread.__init__(self)
+        server = WebsocketServer(port)
+        server.set_fn_new_client(fn_new_client)
+        server.set_fn_client_left(fn_client_left)
+        server.set_fn_message_received(fn_message_received)
+        self.server = server
+
+    def run(self):
+        self.server.run_forever()
+
+    def send_to_all(self, message):
+        self.server.send_message_to_all(message)


### PR DESCRIPTION
Initial Steps for Issue #26 

**What's working?**
A WebSocket server is made to run on ws://127.0.0.1:5678 which send all the queries from Susi Hardware device like a Raspberry Pi to the socket. A client can listen on this interface  ws://127.0.0.1:5678  to get queries.

**What I am working on currently?**
- Adding ability to receive Susi JSON response through websocket which will be sent via client. It is need so that only one API call is made to Susi Server.
- Refactoring code for Readability. 

**Updates:**
- Modified the Websocket library to https://github.com/Pithikos/python-websocket-server . Were having issues in previous library.
- Added JSON Support , now JSON is sent via modified Susi_webchat client to Susi Hardware and response is parsed there. Link to that will be added here. 
Link to changes in Susi Webchat (not synced with upstream, needs a little change) https://github.com/betterclever/chat.susi.ai/commit/42b8f1f3b1c0eaa46b1afcf78e6137f4e73970ea
- Port for WebSocket changed to 9001 from 5678